### PR TITLE
Add missing protos layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         run: pip install -r requirements.txt
       - name: oelint-adv
         run: |
-          find . -type d \( -iname packagegroups \) -prune -false -o \
+          find . -type d \( -iname packagegroups -o -iname recipes-dummy \) -prune -false -o \
             \( -name "*.bb" -o -name "*.bbappend" \) \
             -exec oelint-adv {} +
-

--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -10,6 +10,7 @@ BBLAYERS ?= " \
    ${TOPDIR}/../meta-mingw \
    ${TOPDIR}/../meta-oe/meta-oe \
    ${TOPDIR}/../meta-oe/meta-python \
+   ${TOPDIR}/../protos \
    ${TOPDIR}/../meta-protos \
    ${TOPDIR}/../meta-protos/meta \
    ${TOPDIR}/../meta-protos/meta-oe \

--- a/recipes-dummy/README.md
+++ b/recipes-dummy/README.md
@@ -1,0 +1,3 @@
+This directory is a placeholder only.
+
+Layers need at least one .bb file.

--- a/recipes-dummy/dummy/dummy_0.1.bb
+++ b/recipes-dummy/dummy/dummy_0.1.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Dummy recipe (does nothing)"
+DESCRIPTION = "Placeholder to avoid 'no .bb files' warnings – does nothing"
+AUTHOR = "protos"
+HOMEPAGE = "https://github.com/jhnc-oss/protos"
+BUGTRACKER = "https://github.com/jhnc-oss/protos/issues"
+SECTION = "none"
+LICENSE = "MIT"
+
+BBCLASSEXTEND = ""
+CVE_PRODUCT = ""
+
+do_show_info[doc] = "Dummy - does nothing"
+python do_show_info() {
+    bb.plain("-------------------------------------")
+    bb.plain("  This recipe is a placeholder only  ")
+    bb.plain("-------------------------------------")
+}
+
+addtask show_info before do_build


### PR DESCRIPTION
The Protos layer itself was missing, causing a build error.

There's still a warning regarding _"No bb files matched BBFILE_PATTERN_protos"_ though.