### PR TITLE
Fail linting if there's an issue

### DIFF
--- a/.oelint.cfg
+++ b/.oelint.cfg
@@ -1,6 +1,5 @@
 [oelint]
 suppress =
     oelint.vars.homepageping
-exit-zero = True
 quiet = True
 color = True


### PR DESCRIPTION
Otherwise CI builds stay green even though issues are reported.

closes #4 