### PR TITLE
Remove dependency listing and link to related repos instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,10 @@
 
 Repository of the Protos Yocto distribution.
 
-## Dependencies
 
-This layer depends on:
+- [**meta-protos**](https://github.com/jhnc-oss/meta-protos): Meta layer
+- [**yocto-manifest**](https://github.com/jhnc-oss/yocto-manifests): Repository manifest
 
-| meta layer          | project repository                    |
-| ------------------- | ------------------------------------- |
-| poky                | [poky/dunfell](https://git.yoctoproject.org/cgit/cgit.cgi/poky/log/?h=dunfell)   |
-| meta-protos         | [meta-protos](https://github.com/jhnc-oss/meta-protos)   |
-| meta-clang          | [meta-clang/dunfell](https://github.com/jhnc-oss/meta-clang/tree/dunfell)        |
-| meta-mingw          | [meta-mingw/dunfell](https://github.com/jhnc-oss/meta-mingw/tree/dunfell)        |
-| meta-openembedded   | [meta-openembedded/dunfell](https://github.com/jhnc-oss/meta-openembedded/tree/dunfell)        |
-| meta-python2        | [meta-python2/dunfell](https://github.com/jhnc-oss/meta-python2/tree/dunfell)        |
-| meta-qt5            | [meta-qt5/dunfell](https://github.com/jhnc-oss/meta-qt5/tree/h5b/dunfell-5.12.4) |
-| meta-selinux        | [meta-selinux/dunfell](https://github.com/jhnc-oss/meta-selinux/tree/dunfell)        |
 
 ## TODOs
 


### PR DESCRIPTION
The listed dependencies are out of date and honestly it's not worth the effort since all layers are listed in `bblayers.conf.sample` already.

Links added to related repos.