### PR TITLE
add new meta-python layer in protos

### DIFF
--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -20,6 +20,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../meta-oe/meta-xfce \
     ${TOPDIR}/../meta-protos \
     ${TOPDIR}/../meta-protos/meta \
+    ${TOPDIR}/../meta-protos/meta-python \
     ${TOPDIR}/../meta-protos/meta-oe \
     ${TOPDIR}/../meta-python2 \
     ${TOPDIR}/../meta-python2-backport \


### PR DESCRIPTION
This patch enables the new meta-python layer created by jhnc-oss/meta-protos#117 