### PR TITLE
Sync main to kirkstone

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,19 @@
+name: sync-main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync_to_lts:
+    runs-on: ubuntu-latest
+    name: "Sync 'main' to lts branch"
+    steps:
+      - uses: jojomatik/sync-branch@v1
+        with:
+          source: "main"
+          target: "kirkstone"
+          strategy: "fail"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 
 Repository of the Protos Yocto distribution.
 
-
 - [**meta-protos**](https://github.com/jhnc-oss/meta-protos): Meta layer
 - [**yocto-manifest**](https://github.com/jhnc-oss/yocto-manifests): Repository manifest
 
+## Available Versions
 
+| Yocto Release Branch | Status | Note |
+|:--------------------:|:------:|------|
+| **`kirkstone`**      | :heavy_check_mark: LTS | :arrows_clockwise: Synced from `main` — *do not contribute directly* |
+| **`dunfell`**        | :heavy_check_mark: LTS | |


### PR DESCRIPTION
Sync `main` to `kirkstone` branch and add documentation regarding supported versions (#15).