### PR TITLE
Add meta-protos/meta-python/ layer

### DIFF
--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -22,6 +22,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../meta-protos \
     ${TOPDIR}/../meta-protos/meta \
     ${TOPDIR}/../meta-protos/meta-oe \
+    ${TOPDIR}/../meta-protos/meta-python \
     ${TOPDIR}/../meta-qt5 \
     ${TOPDIR}/../meta-rust \
     ${TOPDIR}/../meta-selinux \


### PR DESCRIPTION
`meta-protos/meta-python/` isn't listed, thus it's recipes aren't found.