### PR TITLE
Remove meta-rust

### DIFF
--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -24,7 +24,6 @@ BBLAYERS ?= " \
     ${TOPDIR}/../meta-protos/meta-oe \
     ${TOPDIR}/../meta-protos/meta-python \
     ${TOPDIR}/../meta-qt5 \
-    ${TOPDIR}/../meta-rust \
     ${TOPDIR}/../meta-selinux \
     ${TOPDIR}/../poky/meta \
     ${TOPDIR}/../poky/meta-poky \


### PR DESCRIPTION
meta-rust was removed from the manifest in https://github.com/jhnc-oss/yocto-manifests/pull/39, but I missed to update bblayers.