### PR TITLE
Use Python 3.12 in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@main
       - uses: actions/setup-python@main
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
       - name: Setup
         run: pip install -r requirements.txt


### PR DESCRIPTION
Uses latest Python in CI builds.