### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
       - uses: actions/checkout@main
       - uses: actions/setup-python@main
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
       - name: Setup
-        run: pip install -r requirements.txt
-      - name: oelint-adv
         run: |
-          find . -type d \( -iname packagegroups -o -iname recipes-dummy \) -prune -false -o \
-            \( -name "*.bb" -o -name "*.bbappend" \) \
-            -exec oelint-adv {} \;
+          sudo apt-get install -y fd-find
+          pip install -r requirements.txt
+      - name: oelint-adv
+        run: fdfind -E "packagegroup*.bb" -e bb -e bbappend . --ignore-file .oelint-ignore -X oelint-adv

--- a/.oelint-ignore
+++ b/.oelint-ignore
@@ -1,0 +1,2 @@
+# Backports from newer Yocto releases
+meta-protos/meta-python/recipes-core/python/python3-uinput/

--- a/meta-protos/recipes-core/images/protos-core-sdk.bb
+++ b/meta-protos/recipes-core/images/protos-core-sdk.bb
@@ -1,6 +1,8 @@
 SUMMARY = "PROTOS core SDK"
 DESCRIPTION = "PROTOS core SDK suitable for development work."
 HOMEPAGE = "https://github.com/jhnc-oss/protos"
+BUGTRACKER = "https://github.com/jhnc-oss/protos/issues"
+SECTION = "development"
 LICENSE = "MIT"
 
 CVE_PRODUCT = ""
@@ -38,3 +40,4 @@ GCC_VERSION = "gcc133"
 TOOLCHAIN_OUTPUTNAME = "${DISTRO}-${SDKMACHINE}-toolchain-${GCC_VERSION}-${MACHINE}-${DISTRO_VERSION}"
 TOOLCHAINEXT_OUTPUTNAME = "${DISTRO}-${SDKMACHINE}-toolchain-ext-${GCC_VERSION}-${MACHINE}-${DISTRO_VERSION}"
 
+BBCLASSEXTEND = ""


### PR DESCRIPTION
Some improvements of the CI build:

- Update to Python 3.13
- `.oelint-ignore` support
- Simplified recipe search
- :warning: The build fails now if there are issues reported

closes #38 