### PR TITLE
Unbreak python3-exceptiongroup

### DIFF
--- a/meta-protos/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup_1.2.0.bb
+++ b/meta-protos/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup_1.2.0.bb
@@ -8,5 +8,7 @@ inherit pypi python_flit_core
 
 PYPI_PACKAGE = "exceptiongroup"
 
+DEPENDS += "python3-flit-scm-native"
+
 BBCLASSEXTEND = "native nativesdk"
 

--- a/meta-protos/meta-python/recipes-devtools/python3-flit-scm/python3-flit-scm.inc
+++ b/meta-protos/meta-python/recipes-devtools/python3-flit-scm/python3-flit-scm.inc
@@ -1,0 +1,10 @@
+SUMMARY = "A PEP 518 build backend."
+DESCRIPTION = "A PEP 518 build backend to generate a version file from VCS."
+AUTHOR = "Will Da Silva <will@willdasilva.xyz>"
+HOMEPAGE = "https://gitlab.com/WillDaSilva/flit_scm"
+BUGTRACKER = "https://gitlab.com/WillDaSilva/flit_scm/-/issues"
+SECTION = "development"
+LICENSE = "MIT"
+
+CVE_PRODUCT = ""
+

--- a/meta-protos/meta-python/recipes-devtools/python3-flit-scm/python3-flit-scm_1.7.0.bb
+++ b/meta-protos/meta-python/recipes-devtools/python3-flit-scm/python3-flit-scm_1.7.0.bb
@@ -1,0 +1,12 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=80f451d0892e64764fe22dbd241b5f02"
+SRC_URI[sha256sum] = "961bd6fb24f31bba75333c234145fff88e6de0a90fc0f7e5e7c79deca69f6bb2"
+
+PYPI_PACKAGE = "flit_scm"
+
+inherit pypi python_flit_core
+
+DEPENDS += "python3-setuptools-scm-native"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Unbreak build of python3-exceptiongroup with poky/scarthgap by providing new recipe for python3-flit-scm, which is a build dependency.

Fixes (#42 )