### PR TITLE
Add python3-nanobind backport

### DIFF
--- a/.oelint-ignore
+++ b/.oelint-ignore
@@ -1,2 +1,4 @@
 # Backports from newer Yocto releases
 meta-protos/meta-python/recipes-core/python/python3-uinput/
+meta-protos/meta-python/recipes-devtools/python3-nanobind/
+meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/

--- a/meta-protos/meta-python/recipes-devtools/python3-nanobind/backport.md
+++ b/meta-protos/meta-python/recipes-devtools/python3-nanobind/backport.md
@@ -1,0 +1,6 @@
+# Backport
+
+Available with *meta-python / master*.
+
+Upstream revision: `74b733358cf94803ff98ecd19d90d0e176be4e71`
+

--- a/meta-protos/meta-python/recipes-devtools/python3-nanobind/python3-nanobind_2.6.1.bb
+++ b/meta-protos/meta-python/recipes-devtools/python3-nanobind/python3-nanobind_2.6.1.bb
@@ -1,0 +1,26 @@
+SUMMARY = "nanobind: tiny and efficient C++/Python bindings"
+DESCRIPTION = "nanobind: tiny and efficient C++/Python bindings"
+HOMEPAGE = "https://github.com/wjakob/nanobind"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7646f9ee25e49eaf53f89a10665c568c"
+
+SRC_URI[sha256sum] = "e05c6816a844aa699e46408add3bff8c743af9fd3d38eafa307a73633fddf94e"
+
+inherit pypi python_setuptools_build_meta cmake lib_package
+
+EXTRA_OECMAKE += "-DNB_TEST=OFF"
+
+DEPENDS += "\
+    python3-scikit-build-native \
+    python3-scikit-build-core-native \
+    ninja-native \
+"
+
+do_install:append() {
+    install -d ${D}${base_libdir}/cmake/${PN}
+    install -m 0644 ${S}/cmake/* ${D}${base_libdir}/cmake/${PN}/
+}
+
+FILES:${PN} += "${prefix_native}/* ${prefix_native}/${PN}/* ${base_libdir}/cmake/*"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/backport.md
+++ b/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/backport.md
@@ -1,0 +1,6 @@
+# Backport
+
+Available with *meta-python / master*.
+
+Upstream revision: `28295bfd591a3d00f706894e01b4f252ee2e1c0a`
+

--- a/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/python3-scikit-build-core/0001-builder.py-Check-PYTHON_INCLUDE_DIR.patch
+++ b/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/python3-scikit-build-core/0001-builder.py-Check-PYTHON_INCLUDE_DIR.patch
@@ -1,0 +1,29 @@
+From 3f5d2be717d200406126537eb2f3ed4de92bd2c1 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Mon, 27 Jan 2025 19:17:48 +0200
+Subject: [PATCH] builder.py: Check PYTHON_INCLUDE_DIR
+
+Use PYTHON_INCLUDE_DIR to find Python Interpreter and
+Development.Module.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Suggested-by: Stephan Kulow <stephan.kulow@siemens.com>
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ src/scikit_build_core/builder/builder.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/scikit_build_core/builder/builder.py b/src/scikit_build_core/builder/builder.py
+index 532d328..0c99ef3 100644
+--- a/src/scikit_build_core/builder/builder.py
++++ b/src/scikit_build_core/builder/builder.py
+@@ -228,7 +228,7 @@ class Builder:
+         python_sabi_library = (
+             get_python_library(self.config.env, abi3=True) if limited_api else None
+         )
+-        python_include_dir = get_python_include_dir()
++        python_include_dir = os.getenv("PYTHON_INCLUDE_DIR") or get_python_include_dir()
+         numpy_include_dir = get_numpy_include_dir()
+ 
+         # Classic Find Python

--- a/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/python3-scikit-build-core_0.11.1.bb
+++ b/meta-protos/meta-python/recipes-devtools/python3-scikit-build-core/python3-scikit-build-core_0.11.1.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Build backend for CMake based projects"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b4e748e5f102e31c9390dcd6fa66f09"
+
+PYPI_PACKAGE = "scikit_build_core"
+UPSTREAM_CHECK_PYPI_PACKAGE = "${PYPI_PACKAGE}"
+
+DEPENDS = "python3-hatch-vcs-native"
+
+inherit pypi python_hatchling
+
+SRC_URI += "file://0001-builder.py-Check-PYTHON_INCLUDE_DIR.patch"
+SRC_URI[sha256sum] = "4e5988df5cd33f0bdb9967b72663ca99f50383c9bc21d8b24fa40c0661ae72b7"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This is a backport of python3-nanobind and python3-scikit-build-core, which is necessary for building it.

Currently, neither package is available through a Yocto release; they are only accessible on the master branch.

I managed to build nanobind by removing the dependency on scikit-build-core, but to avoid introducing any hidden regressions, it’s better to adhere to what's in the meta-python layer.