### PR TITLE
update recipes-oss to latest versions

### DIFF
--- a/meta-protos/meta/conf/layer.conf
+++ b/meta-protos/meta/conf/layer.conf
@@ -11,5 +11,8 @@ BBFILE_PATTERN_meta-protos-meta = "^${LAYERDIR}/"
 # enforce layer precedence
 BBFILE_PRIORITY_meta-protos-meta = "8"
 
+# this layer does contain a .bbclass file only
+BBFILE_PATTERN_IGNORE_EMPTY_meta-protos-meta = "1"
+
 LAYERDEPENDS_meta-protos-meta = "core"
 LAYERSERIES_COMPAT_meta-protos-meta = "kirkstone scarthgap"

--- a/meta-protos/recipes-oss/cppcheck/cppcheck_2.17.1.bb
+++ b/meta-protos/recipes-oss/cppcheck/cppcheck_2.17.1.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "02be7e6e0c35a8b2e46df30b0387beff5c58acb0"
+SRCREV = "ac9db3069b9f90e81e126a090b99ad456e122cf8"
 
 S = "${WORKDIR}/git"
 

--- a/meta-protos/recipes-oss/debugpy/debugpy_1.8.14.bb
+++ b/meta-protos/recipes-oss/debugpy/debugpy_1.8.14.bb
@@ -9,10 +9,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7b6b095fe2a2e2b66cb08d295b605789"
 
 CVE_PRODUCT = ""
 
-SRC_URI[sha256sum] = "12af2c55b419521e33d5fb21bd022df0b5eb267c3e178f1d374a63a2a6bdccd0"
+SRC_URI[sha256sum] = "7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322"
 
 PYPI_PACKAGE = "debugpy"
-PYPI_PACKAGE_EXT = "zip"
+PYPI_PACKAGE_EXT = "tar.gz"
 
 def get_so_suffix(d):
     arch = d.getVar('MACHINE_ARCH')

--- a/meta-protos/recipes-oss/libdmtx/libdmtx_0.7.8.bb
+++ b/meta-protos/recipes-oss/libdmtx/libdmtx_0.7.8.bb
@@ -3,7 +3,7 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b58872aaf3a9d51c1f002b9d7940f4f1"
 
 SRC_URI = "git://github.com/dmtx/libdmtx.git;protocol=https;branch=master"
-SRCREV = "dafd3dd813fb448eab0272f139d45a6b894912df"
+SRCREV = "500d7af6106713610a0f8b2d96aefa81912b96bc"
 
 S = "${WORKDIR}/git"
 

--- a/meta-protos/recipes-oss/libspnav/libspnav_1.2.bb
+++ b/meta-protos/recipes-oss/libspnav/libspnav_1.2.bb
@@ -6,7 +6,7 @@ SRC_URI = "\
     git://github.com/FreeSpacenav/libspnav.git;protocol=https;branch=master \
     file://configure_libdir.patch \
 "
-SRCREV = "1716ccf15fa59a3acaeb9805262fc23613fd6a40"
+SRCREV = "d641e5cbbe0d6d2381a2ee8d95c8c7273d005272"
 
 S = "${WORKDIR}/git"
 

--- a/meta-protos/recipes-oss/nlopt/nlopt_2.10.0.bb
+++ b/meta-protos/recipes-oss/nlopt/nlopt_2.10.0.bb
@@ -11,11 +11,11 @@ LIC_FILES_CHKSUM = "\
     file://src/algs/bobyqa/COPYRIGHT;md5=700dca4c1a2d3517d2e372b064b09ec5 \
     file://src/algs/ags/COPYRIGHT;md5=df8018c0130b3c4b5961d163c169567b \
     file://COPYRIGHT;md5=1b4ae9cf9d4ec57f6dc120948e9b483a \
-    file://COPYING;md5=7036bf07f719818948a837064b1af213 \
+    file://COPYING;md5=bd64d5de9621ced0bbf488c45413e534 \
 "
 
 SRC_URI = "git://github.com/stevengj/nlopt.git;protocol=https;branch=master"
-SRCREV = "09b3c2a6da71cabcb98d2c8facc6b83d2321ed71"
+SRCREV = "7d04da19236148f9ae9d8dfa470a2264f5d2aa33"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update recipes-oss to most recent versions and suppress warning due to missing bb files in layer.conf of meta-protos/meta