### PR TITLE
Add python3-iniparse

### DIFF
--- a/meta-protos/meta-python/recipes-core/python/python3-iniparse/python3-iniparse_0.5.bb
+++ b/meta-protos/meta-python/recipes-core/python/python3-iniparse/python3-iniparse_0.5.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Accessing and Modifying INI files"
+DESCRIPTION = "Python iniparse module with patches from Fedora project"
+HOMEPAGE = "https://github.com/candlepin/python-iniparse"
+BUGTRACKER = "https://github.com/candlepin/python-iniparse/issues"
+SECTION = "development"
+LICENSE = "MIT & PSF-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE-PSF;md5=1c78a5bb3584b353496d5f6f34edb4b2 \
+                    file://LICENSE;md5=52f28065af11d69382693b45b5a8eb54"
+
+SRC_URI[sha256sum] = "932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842"
+
+inherit pypi setuptools3
+
+DEPENDS += "python3-six"
+RDEPENDS:${PN} += "python3-core python3-six"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The package was removed from openembedded-core after Styhead (Yocto Project 5.1).

Upstream commit: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?h=wrynose&id=5915e70469fa53600dd8926ddafcb5459df1a32c

This PR adds the recipe from oe-core, additionally some missing metadata.